### PR TITLE
Add Kubernetes Manifests

### DIFF
--- a/cmd/goul/Dockerfile
+++ b/cmd/goul/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:alpine AS build
+RUN apk add --update git gcc musl-dev libpcap-dev openssh-client
+
+WORKDIR /app
+COPY . .
+RUN go mod init nexclipper/goul
+RUN go mod tidy
+RUN go build -o goul
+
+FROM alpine
+LABEL version=0.1.0
+RUN apk add --update --no-cache libpcap-dev
+COPY --from=build /app/goul /usr/bin/goul
+CMD [ "goul", "--help" ]

--- a/cmd/goul/docker-compose.yml
+++ b/cmd/goul/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+services: 
+  goul-server:
+    image: nexclipper/goul:0.2-head
+    restart: always
+    privileged: true 
+    environment: 
+      - GOUL_DEVICE="eth0"
+    ports:
+      - "6001:6001"
+    command:
+      - goul
+      - --server
+      - --debug
+      - --dev=eth0
+
+  goul-client:
+    image: nexclipper/goul:0.2-head
+    depends_on: 
+      - goul-server
+    links:
+      - goul-server
+    environment: 
+      - GOUL_SERVER_ADDRESS="goul-server"
+      - GOUL_DEVICE="eth0"
+    command:
+      - goul
+      - --addr=goul-server
+      - --dev=eth0
+      - --debug

--- a/cmd/goul/goul-client.yml
+++ b/cmd/goul/goul-client.yml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goul-client
+  namespace: nc
+  labels:
+    app: goul-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: goul-client
+  template:
+    metadata:
+      labels:
+        app: goul-client
+    spec:
+      # nodeSelector:
+      #   key: client
+      hostNetwork: true
+      containers:
+      - name: goul-client
+        image: nexclipper/goul:0.2-head
+        ports:
+        - containerPort: 6001
+        env:
+        - name: GOUL_PORT
+          value: "6001"
+        - name: GOUL_DEVICE
+          value: "ens6f0"
+        - name: GOUL_SERVER_ADDRESS
+          value: "172.16.9.126"
+        command: ["goul"]
+        args: ["--addr=$(GOUL_SERVER_ADDRESS)", "--debug", "--dev=$(GOUL_DEVICE)", "--port=$(GOUL_PORT)"]

--- a/cmd/goul/goul-server.yml
+++ b/cmd/goul/goul-server.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goul-server
+  namespace: nc
+  labels:
+    app: goul-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: goul-server
+  template:
+    metadata:
+      labels:
+        app: goul-server
+    spec:
+      # nodeSelector:
+      #   key: server
+      hostNetwork: true
+      containers:
+      - name: goul-server
+        image: nexclipper/goul:0.2-head
+        ports:
+        - containerPort: 6001
+        env:
+        - name: GOUL_DEVICE
+          value: "ens6f0"
+        command: ["goul"]
+        args: ["--server", "--debug", "--dev=$(GOUL_DEVICE)"]


### PR DESCRIPTION
Added manifest for docker-compose & Kubernetes environments
- image repository : nexclipper/goul:0.2-head
- tested on multi-node Kubernetes Cluster & Docker Desktop
- use option "hostNetwork: true"